### PR TITLE
Add customization options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,24 @@
 Plover Layout Display
 =====================
 
-Display the last stroke in a visual format for English stenography.
+Display the last stroke in Plover.
 
-.. image:: https://i.imgur.com/678YpG9.png
+.. image:: https://i.imgur.com/8AqhQk4.png
 
-Current Features
+Custom Layouts
 ----------------
 
-- Display the last stroke that was hit.
+You can customize the display in various ways by loading your own layout file. Layout file preferences are saved and loaded automatically for each stenography system that you use them for.
+
+See the `stenography layout JSON Schema <https://github.com/nsmarkop/plover_layout_display/blob/cb8ede4a2221e08cd44345c324a9874f8195fcb8/layout_display/resources/steno_layout.schema.json>`__ for the format to use when creating your own layout files.
+
+Some examples of custom layouts:
+
+.. image:: https://i.imgur.com/qjZ0uwn.png
+
+|
+
+.. image:: https://i.imgur.com/7zT77kL.png
 
 Wishlist
 --------
@@ -18,10 +28,7 @@ Wishlist
 This plugin isn't high on my priority list so please feel free to implement any of the below, or suggest new features.
 
 - Add a settings area.
-- Add optional key labeling.
-- Support customizing the colors.
 - Add a fade for the last chord to a user-specified time.
-- Support other theories and custom layouts.
 
 License
 -------

--- a/layout_display/layout_display.py
+++ b/layout_display/layout_display.py
@@ -17,7 +17,7 @@ from layout_display.steno_layout import StenoLayout
 _ = get_gettext()
 
 class LayoutDisplay(Tool, Ui_LayoutDisplay):
-    ''' Steno layout display of strokes '''
+    ''' Stenography layout display of strokes '''
 
     TITLE = _('Layout Display')
     ROLE = 'layout_display'

--- a/layout_display/layout_display.py
+++ b/layout_display/layout_display.py
@@ -39,6 +39,7 @@ class LayoutDisplay(Tool, Ui_LayoutDisplay):
 
         self.restore_state()
 
+        self.finished.connect(self.save_state)
         self.button_reset.clicked.connect(self.on_reset)
         self.button_load.clicked.connect(self.on_load)
         engine.signal_connect('config_changed', self.on_config_changed)

--- a/layout_display/layout_display.py
+++ b/layout_display/layout_display.py
@@ -1,125 +1,271 @@
-import time
-from collections import namedtuple
-from math import ceil
+from typing import List, Tuple
+from pathlib import Path
 
-from PyQt5.QtCore import Qt, QTimer
-from PyQt5.QtGui import QPainter, QFont, QColor, QPainterPath, QBrush
+from PyQt5.QtCore import Qt, QSettings, QRectF, QMarginsF
+from PyQt5.QtGui import QColor, QPainterPath, QBrush, QPen, QResizeEvent
+from PyQt5.QtWidgets import QGraphicsScene, QFileDialog
 
 from plover import system
+from plover.config import CONFIG_DIR
+from plover.engine import StenoEngine
+from plover.steno import Stroke
 from plover.gui_qt.i18n import get_gettext
 from plover.gui_qt.tool import Tool
 
 from layout_display.layout_display_ui import Ui_LayoutDisplay
+from layout_display.steno_layout import StenoLayout
+
 
 _ = get_gettext()
 
-
 class LayoutDisplay(Tool, Ui_LayoutDisplay):
-
-    ''' Paper tape display of strokes. '''
+    ''' Steno layout display of strokes '''
 
     TITLE = _('Layout Display')
     ROLE = 'layout_display'
     ICON = ':/layout_display/steno_key.svg'
 
-    def __init__(self, engine):
+    def __init__(self, engine: StenoEngine):
         super(LayoutDisplay, self).__init__(engine)
         self.setupUi(self)
+
+        self.graphics_scene = QGraphicsScene()
+
         self._stroke = []
+        self._numbers = set()
+        self._numbers_to_keys = {}
+        self._number_key = ''
+        self._system_name = ''
+        self._system_file_map = {}
+
+        self._layout = StenoLayout()
+        self._layout_file_path = ''
+
+        self.restore_state()
+
+        self.button_reset.clicked.connect(self.on_reset)
+        self.button_load.clicked.connect(self.on_load)
         engine.signal_connect('config_changed', self.on_config_changed)
         self.on_config_changed(engine.config)
         engine.signal_connect('stroked', self.on_stroke)
 
-    @staticmethod
-    def _set_label_color(label, color, opacity=255):
-        label.setStyleSheet(
-            'color: rgba(%s, %s, %s, %s)' % (
-                color.red(), color.green(), color.blue(), opacity
-            )
-        )
+        self.update_layout_view(self._layout)
+
+    def _save_state(self, settings: QSettings):
+        ''' 
+        Save state to settings.
+        Called via save_state through plover.qui_qt.utils.WindowState
+        '''
+
+        settings.setValue('system_file_map', self._system_file_map)
+
+    def _restore_state(self, settings: QSettings):
+        '''
+        Restore state from settings.
+        Called via restore_state through plover.qui_qt.utils.WindowState
+        '''
+
+        self._system_file_map = settings.value('system_file_map', {}, dict)
 
     def on_config_changed(self, config):
-        if 'system_name' in config:
-            self._stroke = []
-            self._numbers = set(system.NUMBERS.values())
-            self._numbers_to_keys = {v: k for k, v in system.NUMBERS.items()}
+        ''' Updates state based off of the new Plover configuration '''
 
-    def paintEvent(self, event):
-        padding = 4
-        key_width = 30
-        key_height = 35
-        StenoKey = namedtuple('StenoKey', 'x y w h rounded key_name')
-        keys = (
-            [ StenoKey(0, 0, 10, 0.5, False, '#'),
-              StenoKey(0, 0.5, 1, 2, True, 'S-'),
-              StenoKey(4, 0.5, 1, 2, True, '*'),
-            ] + [StenoKey(x + 1, 0.5, 1, 1, False, letter)
-                 for x, letter in enumerate('T-,P-,H-,,-F,-P,-L,-T,-D'.split(',')) if letter]
-              + [StenoKey(x + 1, 1.5, 1, 1, True, letter)
-                 for x, letter in enumerate('K-,W-,R-,,-R,-B,-G,-S,-Z'.split(',')) if letter]
-              + [StenoKey(x + 2.2, 2.5, 1, 1, True, letter) for x, letter in enumerate(['A-', 'O-'])]
-              + [StenoKey(x + 4.8, 2.5, 1, 1, True, letter) for x, letter in enumerate(['-E', '-U'])]
-        )
-        qp = QPainter()
-        qp.begin(self)
-        qp.setRenderHint(QPainter.Antialiasing)
-        painting_width = 10 * (key_width + padding) + padding
-        painting_height = 3.5 * (key_height + padding) + padding * 1.5
-        qp.setWindow(0, 0, painting_width, painting_height)
-        min_scale = min(self.width() / painting_width, self.height() / painting_height)
-        qp.translate(
-            (abs(self.width() / min_scale - painting_width)) / 2,
-            (abs(self.height() / min_scale - painting_height)) / 2
-        )
-        qp.setViewport(0, 0, painting_width * min_scale, painting_height * min_scale)
-        filled_key_brush = QBrush(QColor.fromRgb(0, 0, 0))
+        # TODO: when does this actually happen...?
+        if 'system_name' not in config:
+            return
 
-        key_paths = {}
+        self._stroke = []
+        self._numbers = set(system.NUMBERS.values())
+        self._numbers_to_keys = {v: k for k, v in system.NUMBERS.items()}
+        self._number_key = system.NUMBER_KEY
+        self._system_name = config['system_name']
 
-        for x, y, w, h, rounded, key_name in keys:
-            w = key_width * w + ceil(w - 1) * padding
-            h = key_height * h + ceil(h - 1) * padding
-            path = key_paths.get((w, h, rounded))
-            if path is None:
-                path = self._steno_key_path(1, 1, w, h, rounded)
-                key_paths[(w, h, rounded)] = path
-            x = (x + 1) * padding + x * key_width
-            y = ceil(y + 1) * padding + y * key_height
-            qp.save()
-            qp.translate(x, y)
-            (qp.fillPath(path, filled_key_brush)
-             if key_name in self._stroke
-             else qp.drawPath(path)
-            )
-            qp.restore()
-        qp.end()
+        # Respect layout padding by manipulating the scene's rect during update
+        # TODO: this doesn't work, just removes some and adds it back.
+        #       need to make it only add once per config change and not remove
+        #       if no margins existed before. And, need to move it so that it
+        #       happens before show but after the paths get added or scaling
+        #       won't work I'm pretty sure
+        padding_old = self._layout.padding
+        # scene_rect = self.graphics_scene.sceneRect()
+        # scene_rect = scene_rect.marginsRemoved(QMarginsF(padding_old, padding_old,
+        #                                                  padding_old, padding_old))
 
-    def _steno_key_path(self, x, y, w, h, rounded=False, corner_radius=0):
-        ellipse_y = min((w, h / 2)) if rounded else 0
-        height_offset = ellipse_y / 2 if rounded else 0
-        box = QPainterPath()
-        if corner_radius:
-            box_height = h - height_offset + (corner_radius if rounded else 0)
-            box.addRoundedRect(x, y, w, box_height, corner_radius, corner_radius)
+        # If the user has no valid preference then fall back to the default
+        preferred_layout_file = self.get_preferred_layout(self._system_name)
+        if not preferred_layout_file:
+            self.on_reset()
         else:
-            box.addRect(x, y, w, h - height_offset)
-        if rounded:
-            round_bottom = QPainterPath()
+            self._layout_file_path = preferred_layout_file
+            self._system_file_map[self._system_name] = self._layout_file_path
+            self.save_state()
 
-            round_bottom.addEllipse(x, y + h - height_offset - ellipse_y / 2, w, ellipse_y)
-            box = box.united(round_bottom)
-        return box
+            self._layout.load_from_file(preferred_layout_file)
+            self.label_layout_name.setText(self._layout.name)
+            self.update_layout_view(self._layout)
 
-    def drawText(self, event, qp):
-        qp.setPen(QColor(168, 34, 3))
-        qp.setFont(QFont('Decorative', 10))
-        qp.drawRect(10, 10, 100, 100)
-        qp.drawText(event.rect(), Qt.AlignCenter, 'booop')
+        # padding_new = self._layout.padding
+        # scene_rect = scene_rect.marginsAdded(QMarginsF(padding_new, padding_new,
+        #                                                padding_new, padding_new))
+        # self.graphics_scene.setSceneRect(scene_rect)
 
-    def on_stroke(self, stroke):
+    def on_stroke(self, stroke: Stroke):
+        ''' Updates state based off of the latest stroke by the user '''
+
         keys = stroke.steno_keys[:]
+
+        # Handle converting numbers in the stroke to the actual key values
         if any(key in self._numbers for key in keys):
-            keys.append('#')
+            keys.append(self._number_key)
         keys = [self._numbers_to_keys[x] if x in self._numbers_to_keys else x for x in keys]
+
         self._stroke = keys
-        self.update()
+        self.update_layout_view(self._layout, keys)
+
+    def on_reset(self):
+        ''' Resets the layout to the built-in default layout '''
+
+        self._layout_file_path = ''
+        if self._system_name in self._system_file_map:
+            self._system_file_map.pop(self._system_name)
+            self.save_state()
+
+        self._layout.load_from_resource(':/layout_display/english_stenotype.json')
+        self.label_layout_name.setText(self._layout.name)
+        self.update_layout_view(self._layout)
+
+    def on_load(self):
+        ''' Gets a layout file from the user to load '''
+
+        # The API says this should return a string, but it returns a tuple
+        file_path, _ = QFileDialog.getOpenFileName(self, 'Open Layout File', CONFIG_DIR, '(*.json)')
+
+        # If the user cancelled out of the dialog then we will have a null string
+        if not file_path:
+            return
+
+        self._layout_file_path = file_path
+        self._system_file_map[self._system_name] = self._layout_file_path
+        self.save_state()
+
+        self._layout.load_from_file(file_path)
+        self.label_layout_name.setText(self._layout.name)
+        self.update_layout_view(self._layout)
+
+    def get_preferred_layout(self, system_name: str) -> str:
+        ''' Gets the user's preferred layout file for the given system '''
+
+        # Restore state to make sure our system to file mapping is up to date
+        self.restore_state()
+
+        file_path = ''
+        if system_name in self._system_file_map:
+            file_path = self._system_file_map[system_name]
+
+        # At least validate the file exists
+        if file_path and not Path(file_path).is_file():
+            file_path = ''
+            if self._system_name in self._system_file_map:
+                self._system_file_map.pop(self._system_name)
+                self.save_state()
+
+        return file_path
+
+    def update_layout_view(self, steno_layout: StenoLayout, stroke: List[str] = []):
+        ''' Updates the current layout display for the provided stroke '''
+
+        # Clear all items from the scene. Could probably be made more efficient...
+        graphics_scene = self.graphics_scene
+        graphics_scene.clear()
+
+        scene_pen = QPen(QColor('#000000'), 1, Qt.SolidLine, Qt.SquareCap, Qt.BevelJoin)
+
+        for key_path, path_brush in LayoutDisplay._get_key_paths(steno_layout, stroke):
+            if not key_path or not path_brush:
+                break
+
+            graphics_scene.addPath(key_path, scene_pen, path_brush)
+
+        # Scene rects don't shrink when items are removed, so need to manually
+        # set it to the current size needed by the contained items
+        graphics_scene.setSceneRect(graphics_scene.itemsBoundingRect())
+
+        self.layout_display_view.setScene(graphics_scene)
+        self.layout_display_view.show()
+        # TODO: this actually needs to happen in the showEvent of the view
+        self.layout_display_view.fitInView(graphics_scene.sceneRect(), Qt.KeepAspectRatio)
+
+    @staticmethod
+    def _get_key_paths(steno_layout: StenoLayout, stroke: List[str]) -> List[Tuple[QPainterPath, QBrush]]:
+        ''' Constructs paths for the layout '''
+
+        key_paths = []
+
+        key_width = steno_layout.key_width
+        key_height = steno_layout.key_height
+
+        for key in steno_layout.keys:
+            x = key.position_x * key_width
+            y = key.position_y * key_height
+            w = key_width * key.width
+            h = key_height * key.height
+
+            path = LayoutDisplay._steno_key_path(x, y, w, h,
+                                                 key.is_round_top, key.is_round_bottom)
+
+            # Determine what color the path should be filled with
+            is_in_stroke = (key.name in stroke)
+            if is_in_stroke and key.color_pressed:
+                path_brush = QBrush(QColor(key.color_pressed))
+            elif not is_in_stroke and key.color:
+                path_brush = QBrush(QColor(key.color))
+            else:
+                path_brush = QBrush()
+
+            key_paths.append((path, path_brush))
+
+        return key_paths
+
+    @staticmethod
+    def _steno_key_path(x, y, w, h, round_top, round_bottom, corner_radius=0) -> QPainterPath:
+        ''' Creates the generic path for a key '''
+
+        # These allow us to make the main key and rounded portions separately
+        h_ellipse = min((w, h / 2))
+
+        y = y + h_ellipse / 2 if round_top else y
+        if round_top and round_bottom:
+            h = h - h_ellipse
+        elif round_top or round_bottom:
+            h = h - h_ellipse / 2
+
+        # Construct the main key shape
+        key_path = QPainterPath()
+        if corner_radius:
+            key_path.addRect(x, y, w, h)
+            # TODO: Actually figure out this case
+            # box_height = h - height_offset + (corner_radius if round_bottom else 0)
+            # box.addRoundedRect(x, y, w, box_height, corner_radius, corner_radius)
+        else:
+            key_path.addRect(x, y, w, h)
+
+        # Add on the rounded top and bottom parts
+        if round_top:
+            key_top = QPainterPath()
+
+            key_top.addEllipse(x, y - h_ellipse / 2, w, h_ellipse)
+            key_path = key_path.united(key_top)
+        if round_bottom:
+            key_bottom = QPainterPath()
+
+            key_bottom.addEllipse(x, y + h - h_ellipse / 2, w, h_ellipse)
+            key_path = key_path.united(key_bottom)
+
+        return key_path
+
+    def resizeEvent(self, event: QResizeEvent):
+        ''' Qt resize event '''
+
+        # Make sure that the layout display scene scales to the view
+        if self.graphics_scene:
+            self.layout_display_view.fitInView(self.graphics_scene.sceneRect(), Qt.KeepAspectRatio)

--- a/layout_display/layout_display.py
+++ b/layout_display/layout_display.py
@@ -67,6 +67,11 @@ class LayoutDisplay(Tool, Ui_LayoutDisplay):
     def on_config_changed(self, config):
         ''' Updates state based off of the new Plover configuration '''
 
+        # If something unrelated changes like a new dictionary
+        # being added then the system name will not be in config
+        if 'system_name' not in config:
+            return
+
         self._stroke = []
         self._numbers = set(system.NUMBERS.values())
         self._numbers_to_keys = {v: k for k, v in system.NUMBERS.items()}

--- a/layout_display/layout_display.py
+++ b/layout_display/layout_display.py
@@ -112,8 +112,9 @@ class LayoutDisplay(Tool, Ui_LayoutDisplay):
         ''' Gets a layout file from the user to load '''
 
         # The API says this should return a string, but it returns a tuple
-        file_path, _ = QFileDialog.getOpenFileName(self, 'Open Layout File',
-                                                   CONFIG_DIR, '(*.json)')
+
+        file_path, _filter = QFileDialog.getOpenFileName(self, _('Open Layout File'),
+                                                         CONFIG_DIR, '(*.json)')
 
         # If the user cancelled out of the dialog then we will have a null string
         if not file_path:

--- a/layout_display/layout_display.py
+++ b/layout_display/layout_display.py
@@ -41,7 +41,7 @@ class LayoutDisplay(Tool, Ui_LayoutDisplay):
 
         self.button_reset.clicked.connect(self.on_reset)
         self.button_load.clicked.connect(self.on_load)
-        
+
         engine.signal_connect('config_changed', self.on_config_changed)
         self.on_config_changed(engine.config)
         engine.signal_connect('stroked', self.on_stroke)
@@ -75,8 +75,7 @@ class LayoutDisplay(Tool, Ui_LayoutDisplay):
 
         # If the user has no valid preference then fall back to the default
         preferred_layout_file = self.get_preferred_layout(self._system_name)
-        if preferred_layout_file:
-            self._layout.load_from_file(preferred_layout_file)
+        if preferred_layout_file and self._layout.load_from_file(preferred_layout_file):
             self.label_layout_name.setText(self._layout.name)
             self.layout_display_view.initialize_view(self._layout)
         else:
@@ -115,11 +114,12 @@ class LayoutDisplay(Tool, Ui_LayoutDisplay):
         if not file_path:
             return
 
-        self._add_system_file_map(self._system_name, file_path)
-
-        self._layout.load_from_file(file_path)
-        self.label_layout_name.setText(self._layout.name)
-        self.layout_display_view.initialize_view(self._layout)
+        if self._layout.load_from_file(file_path):
+            self._add_system_file_map(self._system_name, file_path)
+            self.label_layout_name.setText(self._layout.name)
+            self.layout_display_view.initialize_view(self._layout)
+        else:
+            self.on_reset()
 
     def get_preferred_layout(self, system_name: str) -> str:
         ''' Gets the user's preferred layout file for the given system '''

--- a/layout_display/layout_display.py
+++ b/layout_display/layout_display.py
@@ -17,7 +17,7 @@ from layout_display.steno_layout import StenoLayout
 _ = get_gettext()
 
 class LayoutDisplay(Tool, Ui_LayoutDisplay):
-    ''' Stenography layout display of strokes '''
+    ''' Stenography layout display of strokes. '''
 
     TITLE = _('Layout Display')
     ROLE = 'layout_display'

--- a/layout_display/layout_display.py
+++ b/layout_display/layout_display.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Optional
 
 from PyQt5.QtCore import QSettings
 from PyQt5.QtWidgets import QFileDialog
@@ -127,16 +128,14 @@ class LayoutDisplay(Tool, Ui_LayoutDisplay):
         else:
             self.on_reset()
 
-    def get_preferred_layout(self, system_name: str) -> str:
+    def get_preferred_layout(self, system_name: str) -> Optional[str]:
         ''' Gets the user's preferred layout file for the given system '''
 
-        file_path = ''
-        if system_name in self._system_file_map:
-            file_path = self._system_file_map[system_name]
+        file_path = self._system_file_map.get(system_name)
 
         # At least validate the file still exists
         if file_path and not Path(file_path).is_file():
-            file_path = ''
+            file_path = None
             self._remove_system_file_map(system_name)
             self.save_state()
 

--- a/layout_display/layout_display.py
+++ b/layout_display/layout_display.py
@@ -1,9 +1,7 @@
-from typing import List, Tuple
 from pathlib import Path
 
-from PyQt5.QtCore import Qt, QSettings, QRectF, QMarginsF
-from PyQt5.QtGui import QColor, QPainterPath, QBrush, QPen, QResizeEvent
-from PyQt5.QtWidgets import QGraphicsScene, QFileDialog
+from PyQt5.QtCore import QSettings
+from PyQt5.QtWidgets import QFileDialog
 
 from plover import system
 from plover.config import CONFIG_DIR
@@ -29,8 +27,6 @@ class LayoutDisplay(Tool, Ui_LayoutDisplay):
         super(LayoutDisplay, self).__init__(engine)
         self.setupUi(self)
 
-        self.graphics_scene = QGraphicsScene()
-
         self._stroke = []
         self._numbers = set()
         self._numbers_to_keys = {}
@@ -49,10 +45,10 @@ class LayoutDisplay(Tool, Ui_LayoutDisplay):
         self.on_config_changed(engine.config)
         engine.signal_connect('stroked', self.on_stroke)
 
-        self.update_layout_view(self._layout)
+        self.layout_display_view.update_view(self._layout)
 
     def _save_state(self, settings: QSettings):
-        ''' 
+        '''
         Save state to settings.
         Called via save_state through plover.qui_qt.utils.WindowState
         '''
@@ -80,17 +76,6 @@ class LayoutDisplay(Tool, Ui_LayoutDisplay):
         self._number_key = system.NUMBER_KEY
         self._system_name = config['system_name']
 
-        # Respect layout padding by manipulating the scene's rect during update
-        # TODO: this doesn't work, just removes some and adds it back.
-        #       need to make it only add once per config change and not remove
-        #       if no margins existed before. And, need to move it so that it
-        #       happens before show but after the paths get added or scaling
-        #       won't work I'm pretty sure
-        padding_old = self._layout.padding
-        # scene_rect = self.graphics_scene.sceneRect()
-        # scene_rect = scene_rect.marginsRemoved(QMarginsF(padding_old, padding_old,
-        #                                                  padding_old, padding_old))
-
         # If the user has no valid preference then fall back to the default
         preferred_layout_file = self.get_preferred_layout(self._system_name)
         if not preferred_layout_file:
@@ -102,12 +87,7 @@ class LayoutDisplay(Tool, Ui_LayoutDisplay):
 
             self._layout.load_from_file(preferred_layout_file)
             self.label_layout_name.setText(self._layout.name)
-            self.update_layout_view(self._layout)
-
-        # padding_new = self._layout.padding
-        # scene_rect = scene_rect.marginsAdded(QMarginsF(padding_new, padding_new,
-        #                                                padding_new, padding_new))
-        # self.graphics_scene.setSceneRect(scene_rect)
+            self.layout_display_view.update_view(self._layout)
 
     def on_stroke(self, stroke: Stroke):
         ''' Updates state based off of the latest stroke by the user '''
@@ -120,7 +100,7 @@ class LayoutDisplay(Tool, Ui_LayoutDisplay):
         keys = [self._numbers_to_keys[x] if x in self._numbers_to_keys else x for x in keys]
 
         self._stroke = keys
-        self.update_layout_view(self._layout, keys)
+        self.layout_display_view.update_view(self._layout, keys)
 
     def on_reset(self):
         ''' Resets the layout to the built-in default layout '''
@@ -132,7 +112,7 @@ class LayoutDisplay(Tool, Ui_LayoutDisplay):
 
         self._layout.load_from_resource(':/layout_display/english_stenotype.json')
         self.label_layout_name.setText(self._layout.name)
-        self.update_layout_view(self._layout)
+        self.layout_display_view.update_view(self._layout)
 
     def on_load(self):
         ''' Gets a layout file from the user to load '''
@@ -150,7 +130,7 @@ class LayoutDisplay(Tool, Ui_LayoutDisplay):
 
         self._layout.load_from_file(file_path)
         self.label_layout_name.setText(self._layout.name)
-        self.update_layout_view(self._layout)
+        self.layout_display_view.update_view(self._layout)
 
     def get_preferred_layout(self, system_name: str) -> str:
         ''' Gets the user's preferred layout file for the given system '''
@@ -170,102 +150,3 @@ class LayoutDisplay(Tool, Ui_LayoutDisplay):
                 self.save_state()
 
         return file_path
-
-    def update_layout_view(self, steno_layout: StenoLayout, stroke: List[str] = []):
-        ''' Updates the current layout display for the provided stroke '''
-
-        # Clear all items from the scene. Could probably be made more efficient...
-        graphics_scene = self.graphics_scene
-        graphics_scene.clear()
-
-        scene_pen = QPen(QColor('#000000'), 1, Qt.SolidLine, Qt.SquareCap, Qt.BevelJoin)
-
-        for key_path, path_brush in LayoutDisplay._get_key_paths(steno_layout, stroke):
-            if not key_path or not path_brush:
-                break
-
-            graphics_scene.addPath(key_path, scene_pen, path_brush)
-
-        # Scene rects don't shrink when items are removed, so need to manually
-        # set it to the current size needed by the contained items
-        graphics_scene.setSceneRect(graphics_scene.itemsBoundingRect())
-
-        self.layout_display_view.setScene(graphics_scene)
-        self.layout_display_view.show()
-        # TODO: this actually needs to happen in the showEvent of the view
-        self.layout_display_view.fitInView(graphics_scene.sceneRect(), Qt.KeepAspectRatio)
-
-    @staticmethod
-    def _get_key_paths(steno_layout: StenoLayout, stroke: List[str]) -> List[Tuple[QPainterPath, QBrush]]:
-        ''' Constructs paths for the layout '''
-
-        key_paths = []
-
-        key_width = steno_layout.key_width
-        key_height = steno_layout.key_height
-
-        for key in steno_layout.keys:
-            x = key.position_x * key_width
-            y = key.position_y * key_height
-            w = key_width * key.width
-            h = key_height * key.height
-
-            path = LayoutDisplay._steno_key_path(x, y, w, h,
-                                                 key.is_round_top, key.is_round_bottom)
-
-            # Determine what color the path should be filled with
-            is_in_stroke = (key.name in stroke)
-            if is_in_stroke and key.color_pressed:
-                path_brush = QBrush(QColor(key.color_pressed))
-            elif not is_in_stroke and key.color:
-                path_brush = QBrush(QColor(key.color))
-            else:
-                path_brush = QBrush()
-
-            key_paths.append((path, path_brush))
-
-        return key_paths
-
-    @staticmethod
-    def _steno_key_path(x, y, w, h, round_top, round_bottom, corner_radius=0) -> QPainterPath:
-        ''' Creates the generic path for a key '''
-
-        # These allow us to make the main key and rounded portions separately
-        h_ellipse = min((w, h / 2))
-
-        y = y + h_ellipse / 2 if round_top else y
-        if round_top and round_bottom:
-            h = h - h_ellipse
-        elif round_top or round_bottom:
-            h = h - h_ellipse / 2
-
-        # Construct the main key shape
-        key_path = QPainterPath()
-        if corner_radius:
-            key_path.addRect(x, y, w, h)
-            # TODO: Actually figure out this case
-            # box_height = h - height_offset + (corner_radius if round_bottom else 0)
-            # box.addRoundedRect(x, y, w, box_height, corner_radius, corner_radius)
-        else:
-            key_path.addRect(x, y, w, h)
-
-        # Add on the rounded top and bottom parts
-        if round_top:
-            key_top = QPainterPath()
-
-            key_top.addEllipse(x, y - h_ellipse / 2, w, h_ellipse)
-            key_path = key_path.united(key_top)
-        if round_bottom:
-            key_bottom = QPainterPath()
-
-            key_bottom.addEllipse(x, y + h - h_ellipse / 2, w, h_ellipse)
-            key_path = key_path.united(key_bottom)
-
-        return key_path
-
-    def resizeEvent(self, event: QResizeEvent):
-        ''' Qt resize event '''
-
-        # Make sure that the layout display scene scales to the view
-        if self.graphics_scene:
-            self.layout_display_view.fitInView(self.graphics_scene.sceneRect(), Qt.KeepAspectRatio)

--- a/layout_display/layout_display.ui
+++ b/layout_display/layout_display.ui
@@ -24,6 +24,9 @@
   <property name="windowTitle">
    <string>Layout Display</string>
   </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="grid_layout">
@@ -69,7 +72,7 @@
     </layout>
    </item>
    <item>
-    <widget class="QGraphicsView" name="layout_display_view">
+    <widget class="LayoutDisplayView" name="layout_display_view">
      <property name="accessibleName">
       <string>Layout Display Area</string>
      </property>
@@ -92,6 +95,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>LayoutDisplayView</class>
+   <extends>QGraphicsView</extends>
+   <header>layout_display.layout_graphics</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="resources/resources.qrc"/>
  </resources>

--- a/layout_display/layout_display.ui
+++ b/layout_display/layout_display.ui
@@ -22,15 +22,75 @@
    </font>
   </property>
   <property name="windowTitle">
-   <string>Plover: Layout Display</string>
+   <string>Layout Display</string>
   </property>
-  <property name="sizeGripEnabled">
-   <bool>true</bool>
-  </property>
-  <property name="modal">
-   <bool>false</bool>
-  </property>
-  <layout class="QVBoxLayout" name="verticalLayout"/>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="grid_layout">
+     <item row="1" column="2">
+      <widget class="QPushButton" name="button_load">
+       <property name="toolTip">
+        <string>Select a layout file to load</string>
+       </property>
+       <property name="text">
+        <string>Load</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_layout_name">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="accessibleName">
+        <string>Layout Name</string>
+       </property>
+       <property name="accessibleDescription">
+        <string>The currently loaded layout's name</string>
+       </property>
+       <property name="text">
+        <string>Default Layout Name</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QPushButton" name="button_reset">
+       <property name="toolTip">
+        <string>Reset the layout to the default</string>
+       </property>
+       <property name="text">
+        <string>Reset</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QGraphicsView" name="layout_display_view">
+     <property name="accessibleName">
+      <string>Layout Display Area</string>
+     </property>
+     <property name="accessibleDescription">
+      <string>The display area for the loaded layout</string>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContents</enum>
+     </property>
+     <property name="renderHints">
+      <set>QPainter::Antialiasing|QPainter::TextAntialiasing</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <resources>
   <include location="resources/resources.qrc"/>

--- a/layout_display/layout_graphics.py
+++ b/layout_display/layout_graphics.py
@@ -58,7 +58,7 @@ class LayoutDisplayView(QGraphicsView):
             if key.label:
                 label = QGraphicsTextItem(key.label)
                 label.setFont(font)
-                label.setDefaultTextColor(QColor(steno_layout.font_color))
+                label.setDefaultTextColor(QColor(key.font_color))
 
                 label_rect = label.boundingRect()
                 label_rect.moveCenter(path.boundingRect().center())

--- a/layout_display/layout_graphics.py
+++ b/layout_display/layout_graphics.py
@@ -98,8 +98,8 @@ class LayoutDisplayView(QGraphicsView):
         key_width = steno_layout.key_width
         key_height = steno_layout.key_height
 
-        pos_x = key.position_x * key_width
-        pos_y = key.position_y * key_height
+        pos_x = key.x * key_width
+        pos_y = key.y * key_height
         width = key_width * key.width
         height = key_height * key.height
         is_round_top = key.is_round_top

--- a/layout_display/layout_graphics.py
+++ b/layout_display/layout_graphics.py
@@ -30,7 +30,14 @@ class LayoutDisplayView(QGraphicsView):
         # Make sure the layout display scene is scaled on initial "show"
         self.fitInView(self.graphics_scene.sceneRect(), Qt.KeepAspectRatio)
 
-    def update_view(self, steno_layout: StenoLayout, stroke: List[str] = []):
+    def initialize_view(self, steno_layout: StenoLayout):
+        ''' Initializes the view for the provided layout '''
+
+        # TODO: For now, just call update without a stroke, but these two
+        #       should be optimized to not re-create the scene each time
+        self.update_view(steno_layout, [])
+
+    def update_view(self, steno_layout: StenoLayout, stroke: List[str]):
         ''' Updates the layout display for the provided layout and stroke '''
 
         scene = self.graphics_scene
@@ -98,13 +105,13 @@ class LayoutDisplayView(QGraphicsView):
         ''' Creates the path for a key '''
 
         # Figure out adjustments needed to add rounded parts
-        h_ellipse = min((width, height / 2))
+        ellipse_height = min((width, height / 2))
 
-        pos_y = pos_y + h_ellipse / 2 if is_round_top else pos_y
+        pos_y = pos_y + ellipse_height / 2 if is_round_top else pos_y
         if is_round_top and is_round_bottom:
-            height = height - h_ellipse
+            height = height - ellipse_height
         elif is_round_top or is_round_bottom:
-            height = height - h_ellipse / 2
+            height = height - ellipse_height / 2
 
         # Construct the main key shape
         key_path = QPainterPath()
@@ -114,12 +121,14 @@ class LayoutDisplayView(QGraphicsView):
         if is_round_top:
             key_top = QPainterPath()
 
-            key_top.addEllipse(pos_x, pos_y - h_ellipse / 2, width, h_ellipse)
+            key_top.addEllipse(pos_x, pos_y - ellipse_height / 2,
+                               width, ellipse_height)
             key_path = key_path.united(key_top)
         if is_round_bottom:
             key_bottom = QPainterPath()
 
-            key_bottom.addEllipse(pos_x, pos_y + height - h_ellipse / 2, width, h_ellipse)
+            key_bottom.addEllipse(pos_x, pos_y + height - ellipse_height / 2,
+                                  width, ellipse_height)
             key_path = key_path.united(key_bottom)
 
         return key_path

--- a/layout_display/layout_graphics.py
+++ b/layout_display/layout_graphics.py
@@ -2,7 +2,7 @@ from typing import List, Tuple
 
 from PyQt5.QtCore import Qt, QMarginsF
 from PyQt5.QtWidgets import (QWidget, QGraphicsView, QGraphicsScene,
-                             QGraphicsSimpleTextItem)
+                             QGraphicsTextItem)
 from PyQt5.QtGui import (QPainterPath, QPen, QBrush, QColor,
                          QFont, QResizeEvent, QShowEvent)
 
@@ -46,6 +46,7 @@ class LayoutDisplayView(QGraphicsView):
         font = QFont(steno_layout.font) if steno_layout.font else QFont()
         # Clear all items from the scene. Could be more efficient...
         scene.clear()
+        scene.setBackgroundBrush(QBrush(QColor(steno_layout.background_color)))
 
         for key in steno_layout.keys:
             path = LayoutDisplayView._create_key_path(steno_layout, key)
@@ -55,8 +56,9 @@ class LayoutDisplayView(QGraphicsView):
             scene.addPath(path, pen, brush)
 
             if key.label:
-                label = QGraphicsSimpleTextItem(key.label)
+                label = QGraphicsTextItem(key.label)
                 label.setFont(font)
+                label.setDefaultTextColor(QColor(steno_layout.font_color))
 
                 label_rect = label.boundingRect()
                 label_rect.moveCenter(path.boundingRect().center())

--- a/layout_display/layout_graphics.py
+++ b/layout_display/layout_graphics.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from PyQt5.QtCore import Qt, QMarginsF
 from PyQt5.QtWidgets import (QWidget, QGraphicsView, QGraphicsScene,
@@ -51,6 +51,7 @@ class LayoutDisplayView(QGraphicsView):
         for key in steno_layout.keys:
             path = LayoutDisplayView._create_key_path(steno_layout, key)
             brush = LayoutDisplayView._get_key_path_brush(key, (key.name in stroke))
+            pen.setColor(QColor(key.stroke_color))
 
             # Add the key path before its label, then center the label
             scene.addPath(path, pen, brush)

--- a/layout_display/layout_graphics.py
+++ b/layout_display/layout_graphics.py
@@ -1,0 +1,131 @@
+from typing import List, Tuple
+
+from PyQt5.QtCore import Qt, QMarginsF
+from PyQt5.QtWidgets import QWidget, QGraphicsView, QGraphicsScene
+from PyQt5.QtGui import (QPainterPath, QPen, QBrush, QColor,
+                         QResizeEvent, QShowEvent)
+
+from layout_display.steno_layout import StenoLayout
+
+
+class LayoutDisplayView(QGraphicsView):
+    ''' View to manage Layout Display scenes '''
+
+    def __init__(self, parent: QWidget):
+        super().__init__(parent)
+
+        self.graphics_scene = LayoutDisplayScene(self)
+        self._scene_pen = QPen(QColor('#000000'), 1, Qt.SolidLine,
+                               Qt.SquareCap, Qt.BevelJoin)
+
+    def resizeEvent(self, event: QResizeEvent):
+        ''' Qt resize event '''
+
+        # Make sure the layout display scene scales to the view
+        self.fitInView(self.graphics_scene.sceneRect(), Qt.KeepAspectRatio)
+
+    def showEvent(self, event: QShowEvent):
+        ''' Qt show event '''
+
+        # Make sure the layout display scene is scaled on initial "show"
+        self.fitInView(self.graphics_scene.sceneRect(), Qt.KeepAspectRatio)
+
+    def update_view(self, steno_layout: StenoLayout, stroke: List[str] = []):
+        ''' Updates the layout display for the provided layout and stroke '''
+
+        scene = self.graphics_scene
+        pen = self._scene_pen
+        # Clear all items from the scene. Could be more efficient...
+        scene.clear()
+
+        for path, brush in LayoutDisplayView._get_key_paths(steno_layout, stroke):
+            if not path or not brush:
+                break
+
+            scene.addPath(path, pen, brush)
+
+        # Scene rects don't shrink when items are removed, so need to manually
+        # set it to the current size needed by the contained items + margin
+        margin = steno_layout.margin
+        scene_rect = scene.itemsBoundingRect()
+        scene_rect = scene_rect.marginsAdded(QMarginsF(margin, margin,
+                                                       margin, margin))
+        scene.setSceneRect(scene_rect)
+        self.fitInView(scene.sceneRect(), Qt.KeepAspectRatio)
+
+        self.setScene(scene)
+        self.show()
+
+    @staticmethod
+    def _get_key_paths(steno_layout: StenoLayout,
+                       stroke: List[str]) -> List[Tuple[QPainterPath, QBrush]]:
+        ''' Constructs paths for the layout '''
+
+        key_paths = []
+        key_width = steno_layout.key_width
+        key_height = steno_layout.key_height
+
+        for key in steno_layout.keys:
+            pos_x = key.position_x * key_width
+            pos_y = key.position_y * key_height
+            width = key_width * key.width
+            height = key_height * key.height
+            is_round_top = key.is_round_top
+            is_round_bottom = key.is_round_bottom
+
+            path = LayoutDisplayView._create_key_path(pos_x, pos_y,
+                                                      width, height,
+                                                      is_round_top,
+                                                      is_round_bottom)
+
+            # Determine what color the path should be filled with
+            is_in_stroke = (key.name in stroke)
+            if is_in_stroke and key.color_pressed:
+                path_brush = QBrush(QColor(key.color_pressed))
+            elif not is_in_stroke and key.color:
+                path_brush = QBrush(QColor(key.color))
+            else:
+                path_brush = QBrush()
+
+            key_paths.append((path, path_brush))
+
+        return key_paths
+
+    @staticmethod
+    def _create_key_path(pos_x: float, pos_y: float,
+                         width: float, height: float,
+                         is_round_top: bool, is_round_bottom: bool) -> QPainterPath:
+        ''' Creates the path for a key '''
+
+        # Figure out adjustments needed to add rounded parts
+        h_ellipse = min((width, height / 2))
+
+        pos_y = pos_y + h_ellipse / 2 if is_round_top else pos_y
+        if is_round_top and is_round_bottom:
+            height = height - h_ellipse
+        elif is_round_top or is_round_bottom:
+            height = height - h_ellipse / 2
+
+        # Construct the main key shape
+        key_path = QPainterPath()
+        key_path.addRect(pos_x, pos_y, width, height)
+
+        # Add on the rounded parts
+        if is_round_top:
+            key_top = QPainterPath()
+
+            key_top.addEllipse(pos_x, pos_y - h_ellipse / 2, width, h_ellipse)
+            key_path = key_path.united(key_top)
+        if is_round_bottom:
+            key_bottom = QPainterPath()
+
+            key_bottom.addEllipse(pos_x, pos_y + height - h_ellipse / 2, width, h_ellipse)
+            key_path = key_path.united(key_bottom)
+
+        return key_path
+
+class LayoutDisplayScene(QGraphicsScene):
+    ''' Scene containing all layout display objects '''
+
+    def __init__(self, parent: QWidget):
+        super().__init__(parent)

--- a/layout_display/resources/english_stenotype.json
+++ b/layout_display/resources/english_stenotype.json
@@ -7,8 +7,8 @@
         {
             "name": "#",
             "label": "",
-            "position_x": 0.0,
-            "position_y": 0.0,
+            "x": 0.0,
+            "y": 0.0,
             "width": 10.0,
             "height": 0.5
         },
@@ -16,8 +16,8 @@
         {
             "name": "S-",
             "label": "",
-            "position_x": 0.0,
-            "position_y": 0.5,
+            "x": 0.0,
+            "y": 0.5,
             "width": 1.0,
             "height": 2.0,
             "is_round_bottom": true
@@ -25,32 +25,32 @@
         {
             "name": "T-",
             "label": "",
-            "position_x": 1,
-            "position_y": 0.5,
+            "x": 1.0,
+            "y": 0.5,
             "width": 1.0,
             "height": 1.0
         },
         {
             "name": "P-",
             "label": "",
-            "position_x": 2,
-            "position_y": 0.5,
+            "x": 2.0,
+            "y": 0.5,
             "width": 1.0,
             "height": 1.0
         },
         {
             "name": "H-",
             "label": "",
-            "position_x": 3,
-            "position_y": 0.5,
+            "x": 3.0,
+            "y": 0.5,
             "width": 1.0,
             "height": 1.0
         },
         {
             "name": "*",
             "label": "",
-            "position_x": 4,
-            "position_y": 0.5,
+            "x": 4.0,
+            "y": 0.5,
             "width": 1.0,
             "height": 2.0,
             "is_round_bottom": true
@@ -58,40 +58,40 @@
         {
             "name": "-F",
             "label": "",
-            "position_x": 5,
-            "position_y": 0.5,
+            "x": 5.0,
+            "y": 0.5,
             "width": 1.0,
             "height": 1.0
         },
         {
             "name": "-P",
             "label": "",
-            "position_x": 6,
-            "position_y": 0.5,
+            "x": 6.0,
+            "y": 0.5,
             "width": 1.0,
             "height": 1.0
         },
         {
             "name": "-L",
             "label": "",
-            "position_x": 7,
-            "position_y": 0.5,
+            "x": 7.0,
+            "y": 0.5,
             "width": 1.0,
             "height": 1.0
         },
         {
             "name": "-T",
             "label": "",
-            "position_x": 8,
-            "position_y": 0.5,
+            "x": 8.0,
+            "y": 0.5,
             "width": 1.0,
             "height": 1.0
         },
         {
             "name": "-D",
             "label": "",
-            "position_x": 9,
-            "position_y": 0.5,
+            "x": 9.0,
+            "y": 0.5,
             "width": 1.0,
             "height": 1.0
         },
@@ -99,8 +99,8 @@
         {
             "name": "K-",
             "label": "",
-            "position_x": 1,
-            "position_y": 1.5,
+            "x": 1.0,
+            "y": 1.5,
             "width": 1.0,
             "height": 1.0,
             "is_round_bottom": true
@@ -108,8 +108,8 @@
         {
             "name": "W-",
             "label": "",
-            "position_x": 2,
-            "position_y": 1.5,
+            "x": 2.0,
+            "y": 1.5,
             "width": 1.0,
             "height": 1.0,
             "is_round_bottom": true
@@ -117,8 +117,8 @@
         {
             "name": "R-",
             "label": "",
-            "position_x": 3,
-            "position_y": 1.5,
+            "x": 3.0,
+            "y": 1.5,
             "width": 1.0,
             "height": 1.0,
             "is_round_bottom": true
@@ -126,8 +126,8 @@
         {
             "name": "-R",
             "label": "",
-            "position_x": 5,
-            "position_y": 1.5,
+            "x": 5.0,
+            "y": 1.5,
             "width": 1.0,
             "height": 1.0,
             "is_round_bottom": true
@@ -135,8 +135,8 @@
         {
             "name": "-B",
             "label": "",
-            "position_x": 6,
-            "position_y": 1.5,
+            "x": 6.0,
+            "y": 1.5,
             "width": 1.0,
             "height": 1.0,
             "is_round_bottom": true
@@ -144,8 +144,8 @@
         {
             "name": "-G",
             "label": "",
-            "position_x": 7,
-            "position_y": 1.5,
+            "x": 7.0,
+            "y": 1.5,
             "width": 1.0,
             "height": 1.0,
             "is_round_bottom": true
@@ -153,8 +153,8 @@
         {
             "name": "-S",
             "label": "",
-            "position_x": 8,
-            "position_y": 1.5,
+            "x": 8.0,
+            "y": 1.5,
             "width": 1.0,
             "height": 1.0,
             "is_round_bottom": true
@@ -162,8 +162,8 @@
         {
             "name": "-Z",
             "label": "",
-            "position_x": 9,
-            "position_y": 1.5,
+            "x": 9.0,
+            "y": 1.5,
             "width": 1.0,
             "height": 1.0,
             "is_round_bottom": true
@@ -172,8 +172,8 @@
         {
             "name": "A-",
             "label": "",
-            "position_x": 2.2,
-            "position_y": 2.6,
+            "x": 2.2,
+            "y": 2.6,
             "width": 1.0,
             "height": 1.0,
             "is_round_bottom": true
@@ -181,8 +181,8 @@
         {
             "name": "O-",
             "label": "",
-            "position_x": 3.2,
-            "position_y": 2.6,
+            "x": 3.2,
+            "y": 2.6,
             "width": 1.0,
             "height": 1.0,
             "is_round_bottom": true
@@ -190,8 +190,8 @@
         {
             "name": "-E",
             "label": "",
-            "position_x": 4.8,
-            "position_y": 2.6,
+            "x": 4.8,
+            "y": 2.6,
             "width": 1.0,
             "height": 1.0,
             "is_round_bottom": true
@@ -199,8 +199,8 @@
         {
             "name": "-U",
             "label": "",
-            "position_x": 5.8,
-            "position_y": 2.6,
+            "x": 5.8,
+            "y": 2.6,
             "width": 1.0,
             "height": 1.0,
             "is_round_bottom": true

--- a/layout_display/resources/english_stenotype.json
+++ b/layout_display/resources/english_stenotype.json
@@ -1,28 +1,25 @@
 {
     "name": "English Stenotype",
     "margin": 5.0,
-    "key_width": 30,
-    "key_height": 35,
+    "key_width": 30.0,
+    "key_height": 35.0,
     "keys": [
         {
             "name": "#",
             "label": "",
-            "position_x": 0,
-            "position_y": 0,
-            "width": 10,
-            "height": 0.5,
-            "is_round_top": false,
-            "is_round_bottom": false
+            "position_x": 0.0,
+            "position_y": 0.0,
+            "width": 10.0,
+            "height": 0.5
         },
 
         {
             "name": "S-",
             "label": "",
-            "position_x": 0,
+            "position_x": 0.0,
             "position_y": 0.5,
-            "width": 1,
-            "height": 2,
-            "is_round_top": false,
+            "width": 1.0,
+            "height": 2.0,
             "is_round_bottom": true
         },
         {
@@ -30,39 +27,32 @@
             "label": "",
             "position_x": 1,
             "position_y": 0.5,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
-            "is_round_bottom": false
+            "width": 1.0,
+            "height": 1.0
         },
         {
             "name": "P-",
             "label": "",
             "position_x": 2,
             "position_y": 0.5,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
-            "is_round_bottom": false
+            "width": 1.0,
+            "height": 1.0
         },
         {
             "name": "H-",
             "label": "",
             "position_x": 3,
             "position_y": 0.5,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
-            "is_round_bottom": false
+            "width": 1.0,
+            "height": 1.0
         },
         {
             "name": "*",
             "label": "",
             "position_x": 4,
             "position_y": 0.5,
-            "width": 1,
-            "height": 2,
-            "is_round_top": false,
+            "width": 1.0,
+            "height": 2.0,
             "is_round_bottom": true
         },
         {
@@ -70,50 +60,40 @@
             "label": "",
             "position_x": 5,
             "position_y": 0.5,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
-            "is_round_bottom": false
+            "width": 1.0,
+            "height": 1.0
         },
         {
             "name": "-P",
             "label": "",
             "position_x": 6,
             "position_y": 0.5,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
-            "is_round_bottom": false
+            "width": 1.0,
+            "height": 1.0
         },
         {
             "name": "-L",
             "label": "",
             "position_x": 7,
             "position_y": 0.5,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
-            "is_round_bottom": false
+            "width": 1.0,
+            "height": 1.0
         },
         {
             "name": "-T",
             "label": "",
             "position_x": 8,
             "position_y": 0.5,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
-            "is_round_bottom": false
+            "width": 1.0,
+            "height": 1.0
         },
         {
             "name": "-D",
             "label": "",
             "position_x": 9,
             "position_y": 0.5,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
-            "is_round_bottom": false
+            "width": 1.0,
+            "height": 1.0
         },
 
         {
@@ -121,9 +101,8 @@
             "label": "",
             "position_x": 1,
             "position_y": 1.5,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
+            "width": 1.0,
+            "height": 1.0,
             "is_round_bottom": true
         },
         {
@@ -131,9 +110,8 @@
             "label": "",
             "position_x": 2,
             "position_y": 1.5,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
+            "width": 1.0,
+            "height": 1.0,
             "is_round_bottom": true
         },
         {
@@ -141,9 +119,8 @@
             "label": "",
             "position_x": 3,
             "position_y": 1.5,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
+            "width": 1.0,
+            "height": 1.0,
             "is_round_bottom": true
         },
         {
@@ -151,9 +128,8 @@
             "label": "",
             "position_x": 5,
             "position_y": 1.5,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
+            "width": 1.0,
+            "height": 1.0,
             "is_round_bottom": true
         },
         {
@@ -161,9 +137,8 @@
             "label": "",
             "position_x": 6,
             "position_y": 1.5,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
+            "width": 1.0,
+            "height": 1.0,
             "is_round_bottom": true
         },
         {
@@ -171,9 +146,8 @@
             "label": "",
             "position_x": 7,
             "position_y": 1.5,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
+            "width": 1.0,
+            "height": 1.0,
             "is_round_bottom": true
         },
         {
@@ -181,9 +155,8 @@
             "label": "",
             "position_x": 8,
             "position_y": 1.5,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
+            "width": 1.0,
+            "height": 1.0,
             "is_round_bottom": true
         },
         {
@@ -191,9 +164,8 @@
             "label": "",
             "position_x": 9,
             "position_y": 1.5,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
+            "width": 1.0,
+            "height": 1.0,
             "is_round_bottom": true
         },
 
@@ -202,9 +174,8 @@
             "label": "",
             "position_x": 2.2,
             "position_y": 2.6,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
+            "width": 1.0,
+            "height": 1.0,
             "is_round_bottom": true
         },
         {
@@ -212,9 +183,8 @@
             "label": "",
             "position_x": 3.2,
             "position_y": 2.6,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
+            "width": 1.0,
+            "height": 1.0,
             "is_round_bottom": true
         },
         {
@@ -222,9 +192,8 @@
             "label": "",
             "position_x": 4.8,
             "position_y": 2.6,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
+            "width": 1.0,
+            "height": 1.0,
             "is_round_bottom": true
         },
         {
@@ -232,9 +201,8 @@
             "label": "",
             "position_x": 5.8,
             "position_y": 2.6,
-            "width": 1,
-            "height": 1,
-            "is_round_top": false,
+            "width": 1.0,
+            "height": 1.0,
             "is_round_bottom": true
         }
     ] 

--- a/layout_display/resources/english_stenotype.json
+++ b/layout_display/resources/english_stenotype.json
@@ -1,0 +1,241 @@
+{
+    "name": "English Stenotype",
+    "padding": 4.0,
+    "key_width": 30,
+    "key_height": 35,
+    "keys": [
+        {
+            "name": "#",
+            "label": "",
+            "position_x": 0,
+            "position_y": 0,
+            "width": 10,
+            "height": 0.5,
+            "is_round_top": false,
+            "is_round_bottom": false
+        },
+
+        {
+            "name": "S-",
+            "label": "",
+            "position_x": 0,
+            "position_y": 0.5,
+            "width": 1,
+            "height": 2,
+            "is_round_top": false,
+            "is_round_bottom": true
+        },
+        {
+            "name": "T-",
+            "label": "",
+            "position_x": 1,
+            "position_y": 0.5,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": false
+        },
+        {
+            "name": "P-",
+            "label": "",
+            "position_x": 2,
+            "position_y": 0.5,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": false
+        },
+        {
+            "name": "H-",
+            "label": "",
+            "position_x": 3,
+            "position_y": 0.5,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": false
+        },
+        {
+            "name": "*",
+            "label": "",
+            "position_x": 4,
+            "position_y": 0.5,
+            "width": 1,
+            "height": 2,
+            "is_round_top": false,
+            "is_round_bottom": true
+        },
+        {
+            "name": "-F",
+            "label": "",
+            "position_x": 5,
+            "position_y": 0.5,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": false
+        },
+        {
+            "name": "-P",
+            "label": "",
+            "position_x": 6,
+            "position_y": 0.5,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": false
+        },
+        {
+            "name": "-L",
+            "label": "",
+            "position_x": 7,
+            "position_y": 0.5,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": false
+        },
+        {
+            "name": "-T",
+            "label": "",
+            "position_x": 8,
+            "position_y": 0.5,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": false
+        },
+        {
+            "name": "-D",
+            "label": "",
+            "position_x": 9,
+            "position_y": 0.5,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": false
+        },
+
+        {
+            "name": "K-",
+            "label": "",
+            "position_x": 1,
+            "position_y": 1.5,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": true
+        },
+        {
+            "name": "W-",
+            "label": "",
+            "position_x": 2,
+            "position_y": 1.5,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": true
+        },
+        {
+            "name": "R-",
+            "label": "",
+            "position_x": 3,
+            "position_y": 1.5,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": true
+        },
+        {
+            "name": "-R",
+            "label": "",
+            "position_x": 5,
+            "position_y": 1.5,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": true
+        },
+        {
+            "name": "-B",
+            "label": "",
+            "position_x": 6,
+            "position_y": 1.5,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": true
+        },
+        {
+            "name": "-G",
+            "label": "",
+            "position_x": 7,
+            "position_y": 1.5,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": true
+        },
+        {
+            "name": "-S",
+            "label": "",
+            "position_x": 8,
+            "position_y": 1.5,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": true
+        },
+        {
+            "name": "-Z",
+            "label": "",
+            "position_x": 9,
+            "position_y": 1.5,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": true
+        },
+
+        {
+            "name": "A-",
+            "label": "",
+            "position_x": 2.2,
+            "position_y": 2.6,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": true
+        },
+        {
+            "name": "O-",
+            "label": "",
+            "position_x": 3.2,
+            "position_y": 2.6,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": true
+        },
+        {
+            "name": "-E",
+            "label": "",
+            "position_x": 4.8,
+            "position_y": 2.6,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": true
+        },
+        {
+            "name": "-U",
+            "label": "",
+            "position_x": 5.8,
+            "position_y": 2.6,
+            "width": 1,
+            "height": 1,
+            "is_round_top": false,
+            "is_round_bottom": true
+        }
+    ] 
+}

--- a/layout_display/resources/english_stenotype.json
+++ b/layout_display/resources/english_stenotype.json
@@ -1,6 +1,6 @@
 {
     "name": "English Stenotype",
-    "padding": 4.0,
+    "margin": 5.0,
     "key_width": 30,
     "key_height": 35,
     "keys": [

--- a/layout_display/resources/resources.qrc
+++ b/layout_display/resources/resources.qrc
@@ -1,5 +1,6 @@
 <RCC>
     <qresource prefix="/layout_display">
       <file>steno_key.svg</file>
+      <file>english_stenotype.json</file>
     </qresource>
 </RCC>

--- a/layout_display/resources/resources.qrc
+++ b/layout_display/resources/resources.qrc
@@ -2,5 +2,6 @@
     <qresource prefix="/layout_display">
       <file>steno_key.svg</file>
       <file>english_stenotype.json</file>
+      <file>steno_layout.schema.json</file>
     </qresource>
 </RCC>

--- a/layout_display/resources/steno_layout.schema.json
+++ b/layout_display/resources/steno_layout.schema.json
@@ -8,28 +8,6 @@
             "description": "The name of the layout",
             "type": "string"
         },
-        "font": {
-            "description": "The name for the system font to use for any text",
-            "type": "string"
-        },
-        "font_color": {
-            "description": "ARGB hex code for the default font color",
-            "type": "string",
-            "default": "#000000",
-            "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
-        },
-        "stroke_color": {
-            "description": "ARGB hex code for the color of strokes",
-            "type": "string",
-            "default": "#000000",
-            "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
-        },
-        "background_color": {
-            "description": "ARGB hex code for the color behind the layout",
-            "type": "string",
-            "default": "#FFFFFF",
-            "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
-        },
         "margin": {
             "description": "The margin size on all sides of the layout",
             "type": "number",
@@ -45,6 +23,39 @@
             "type": "number",
             "default": 35.0
         },
+        "font": {
+            "description": "The name for the system font to use for any text",
+            "type": "string"
+        },
+        "font_color": {
+            "description": "ARGB hex code for the default font color",
+            "type": "string",
+            "default": "#000000",
+            "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+        },
+        "background_color": {
+            "description": "ARGB hex code for the color behind the layout",
+            "type": "string",
+            "default": "#FFFFFF",
+            "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+        },
+        "key_stroke_color": {
+            "description": "ARGB hex code for the color of the keys' strokes",
+            "type": "string",
+            "default": "#000000",
+            "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+        },
+        "key_color": {
+            "description": "ARGB hex code for the color of the keys",
+            "type": "string",
+            "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+        },
+        "key_color_pressed": {
+            "description": "ARGB hex code for the color of the keys when pressed",
+            "type": "string",
+            "default": "#000000",
+            "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+        },
         "keys": {
             "description": "The key definitions for the layout",
             "type": "array",
@@ -59,23 +70,23 @@
                         "description": "The text to display in the center of the key",
                         "type": "string"
                     },
-                    "position_x": {
+                    "x": {
                         "description": "The number of key width units from the origin on the x axis the key is",
                         "type": "number",
                         "default": 0.0
                     },
-                    "position_y": {
+                    "y": {
                         "description": "The number of key height units from the origin on the y axis the key is",
                         "type": "number",
                         "default": 0.0
                     },
                     "width": {
-                        "description": "The number of standard key width units the key is",
+                        "description": "The number of key width units the key is",
                         "type": "number",
                         "default": 1.0
                     },
                     "height": {
-                        "description": "The number of standard key height units the key is",
+                        "description": "The number of key height units the key is",
                         "type": "number",
                         "default": 1.0
                     },
@@ -89,24 +100,23 @@
                         "type": "boolean",
                         "default": false
                     },
-                    "color": {
-                        "description": "ARGB hex code for the color of the key",
-                        "type": "string",
-                        "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
-                    },
-                    "color_pressed": {
-                        "description": "ARGB hex code for the color of the key when pressed",
-                        "type": "string",
-                        "default": "#000000",
-                        "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
-                    },
                     "font_color": {
                         "description": "ARGB hex code override for the font color of the key",
                         "type": "string",
                         "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
                     },
                     "stroke_color": {
-                        "description": "ARGB hex code override for the color of strokes for the key",
+                        "description": "ARGB hex code override for the color of key's strokes",
+                        "type": "string",
+                        "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+                    },
+                    "color": {
+                        "description": "ARGB hex code override for the color of the key",
+                        "type": "string",
+                        "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+                    },
+                    "color_pressed": {
+                        "description": "ARGB hex code override for the color of the key when pressed",
                         "type": "string",
                         "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
                     }

--- a/layout_display/resources/steno_layout.schema.json
+++ b/layout_display/resources/steno_layout.schema.json
@@ -18,6 +18,12 @@
             "default": "#000000",
             "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
         },
+        "stroke_color": {
+            "description": "ARGB hex code for the color of strokes",
+            "type": "string",
+            "default": "#000000",
+            "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+        },
         "background_color": {
             "description": "ARGB hex code for the color behind the layout",
             "type": "string",
@@ -96,6 +102,11 @@
                     },
                     "font_color": {
                         "description": "ARGB hex code override for the font color of the key",
+                        "type": "string",
+                        "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+                    },
+                    "stroke_color": {
+                        "description": "ARGB hex code override for the color of strokes for the key",
                         "type": "string",
                         "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
                     }

--- a/layout_display/resources/steno_layout.schema.json
+++ b/layout_display/resources/steno_layout.schema.json
@@ -1,0 +1,112 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Stenography Layout",
+    "description": "A layout used for stenography systems",
+    "type": "object",
+    "properties": {
+        "name": {
+            "description": "The name of the layout",
+            "type": "string"
+        },
+        "font": {
+            "description": "The name for the system font to use for any text",
+            "type": "string"
+        },
+        "font_color": {
+            "description": "ARGB hex code for the default font color",
+            "type": "string",
+            "default": "#000000",
+            "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+        },
+        "background_color": {
+            "description": "ARGB hex code for the color behind the layout",
+            "type": "string",
+            "default": "#FFFFFF",
+            "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+        },
+        "margin": {
+            "description": "The margin size on all sides of the layout",
+            "type": "number",
+            "default": 5.0
+        },
+        "key_width": {
+            "description": "The standard width of a key in the layout",
+            "type": "number",
+            "default": 30.0
+        },
+        "key_height": {
+            "description": "The standard height of a key in the layout",
+            "type": "number",
+            "default": 35.0
+        },
+        "keys": {
+            "description": "The key definitions for the layout",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "description": "The key in the stenography system this key corresponds to",
+                        "type": "string"
+                    },
+                    "label": {
+                        "description": "The text to display in the center of the key",
+                        "type": "string"
+                    },
+                    "position_x": {
+                        "description": "The number of key width units from the origin on the x axis the key is",
+                        "type": "number",
+                        "default": 0.0
+                    },
+                    "position_y": {
+                        "description": "The number of key height units from the origin on the y axis the key is",
+                        "type": "number",
+                        "default": 0.0
+                    },
+                    "width": {
+                        "description": "The number of standard key width units the key is",
+                        "type": "number",
+                        "default": 1.0
+                    },
+                    "height": {
+                        "description": "The number of standard key height units the key is",
+                        "type": "number",
+                        "default": 1.0
+                    },
+                    "is_round_top": {
+                        "description": "If the top of the key should be rounded",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "is_round_bottom": {
+                        "description": "If the bottom of the key should be rounded",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "color": {
+                        "description": "ARGB hex code for the color of the key",
+                        "type": "string",
+                        "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+                    },
+                    "color_pressed": {
+                        "description": "ARGB hex code for the color of the key when pressed",
+                        "type": "string",
+                        "default": "#000000",
+                        "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+                    },
+                    "font_color": {
+                        "description": "ARGB hex code override for the font color of the key",
+                        "type": "string",
+                        "pattern": "^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            }
+        }
+    },
+    "required": [
+        "name"
+    ]
+}

--- a/layout_display/steno_layout.py
+++ b/layout_display/steno_layout.py
@@ -7,39 +7,39 @@ import jsonschema
 
 
 DEF_LAYOUT_NAME = 'Default Layout Name'
-DEF_FONT = ''
-DEF_FONT_COLOR = '#000000'
-DEF_STROKE_COLOR = '#000000'
-DEF_BACKGROUND_COLOR = '#FFFFFF'
 DEF_MARGIN = 5.0
 DEF_KEY_WIDTH = 30.0
 DEF_KEY_HEIGHT = 35.0
+DEF_FONT = ''
+DEF_FONT_COLOR = '#000000'
+DEF_BACKGROUND_COLOR = '#FFFFFF'
+DEF_STROKE_COLOR = '#000000'
+DEF_KEY_COLOR = ''
+DEF_KEY_COLOR_PRESSED = '#000000'
 
 DEF_KEY_LABEL = ''
 DEF_KEY_WIDTH_UNIT = 1.0
 DEF_KEY_HEIGHT_UNIT = 1.0
 DEF_KEY_POS_X = 0.0
 DEF_KEY_POS_Y = 0.0
-DEF_KEY_COLOR = ''
-DEF_KEY_COLOR_PRESSED = '#000000'
 
 StenoKey = namedtuple('StenoKey',
                       'name label ' +
-                      'position_x position_y ' +
+                      'x y ' +
                       'width height ' +
                       'is_round_top is_round_bottom ' +
-                      'color color_pressed font_color stroke_color')
+                      'font_color stroke_color color color_pressed')
 
 class StenoLayout():
     ''' Represents the structure of a stenography layout '''
 
     def __init__(self):
         self.name = DEF_LAYOUT_NAME
-        self.font = DEF_FONT
-        self.background_color = DEF_BACKGROUND_COLOR
         self.margin = DEF_MARGIN
         self.key_width = DEF_KEY_WIDTH
         self.key_height = DEF_KEY_HEIGHT
+        self.font = DEF_FONT
+        self.background_color = DEF_BACKGROUND_COLOR
 
         self.keys: List[StenoKey] = []
 
@@ -77,13 +77,15 @@ class StenoLayout():
             return False
 
         self.name = data['name'] if 'name' in data else DEF_LAYOUT_NAME
-        self.font = data['font'] if 'font' in data else DEF_FONT
-        font_color = data['font_color'] if 'font_color' in data else DEF_FONT_COLOR
-        stroke_color = data['stroke_color'] if 'stroke_color' in data else DEF_STROKE_COLOR
-        self.background_color = data['background_color'] if 'background_color' in data else DEF_BACKGROUND_COLOR
         self.margin = data['margin'] if 'margin' in data else DEF_MARGIN
         self.key_width = data['key_width'] if 'key_width' in data else DEF_KEY_WIDTH
         self.key_height = data['key_height'] if 'key_height' in data else DEF_KEY_HEIGHT
+        self.font = data['font'] if 'font' in data else DEF_FONT
+        font_color = data['font_color'] if 'font_color' in data else DEF_FONT_COLOR
+        self.background_color = data['background_color'] if 'background_color' in data else DEF_BACKGROUND_COLOR
+        key_stroke_color = data['key_stroke_color'] if 'key_stroke_color' in data else DEF_STROKE_COLOR
+        key_color = data['key_color'] if 'key_color' in data else DEF_KEY_COLOR
+        key_color_pressed = data['key_color'] if 'key_color' in data else DEF_KEY_COLOR_PRESSED
 
         self.keys = []
         for key in data['keys']:
@@ -91,16 +93,16 @@ class StenoLayout():
                 # Make sure that name always exists; we'll default to unique
                 key['name'] if 'name' in key else str(len(self.keys)),
                 key['label'] if 'label' in key else DEF_KEY_LABEL,
-                key['position_x'] if 'position_x' in key else DEF_KEY_POS_X,
-                key['position_y'] if 'position_y' in key else DEF_KEY_POS_Y,
+                key['x'] if 'x' in key else DEF_KEY_POS_X,
+                key['y'] if 'y' in key else DEF_KEY_POS_Y,
                 key['width'] if 'width' in key else DEF_KEY_WIDTH_UNIT,
                 key['height'] if 'height' in key else DEF_KEY_HEIGHT_UNIT,
                 key['is_round_top'] if 'is_round_top' in key else False,
                 key['is_round_bottom'] if 'is_round_bottom' in key else False,
-                key['color'] if 'color' in key else DEF_KEY_COLOR,
-                key['color_pressed'] if 'color_pressed' in key else DEF_KEY_COLOR_PRESSED,
                 key['font_color'] if 'font_color' in key else font_color,
-                key['stroke_color'] if 'stroke_color' in key else stroke_color
+                key['stroke_color'] if 'stroke_color' in key else key_stroke_color,
+                key['color'] if 'color' in key else key_color,
+                key['color_pressed'] if 'color_pressed' in key else key_color_pressed
             ))
 
         return True

--- a/layout_display/steno_layout.py
+++ b/layout_display/steno_layout.py
@@ -10,8 +10,8 @@ DEF_FONT = ''
 DEF_FONT_COLOR = '#000000'
 DEF_BACKGROUND_COLOR = '#FFFFFF'
 DEF_MARGIN = 5.0
-DEF_KEY_WIDTH = 30
-DEF_KEY_HEIGHT = 35
+DEF_KEY_WIDTH = 30.0
+DEF_KEY_HEIGHT = 35.0
 
 DEF_KEY_LABEL = ''
 DEF_KEY_WIDTH_UNIT = 1.0
@@ -26,7 +26,7 @@ StenoKey = namedtuple('StenoKey',
                       'position_x position_y ' +
                       'width height ' +
                       'is_round_top is_round_bottom ' +
-                      'color color_pressed')
+                      'color color_pressed font_color')
 
 class StenoLayout():
     ''' Represents the structure of a stenography layout '''
@@ -34,7 +34,6 @@ class StenoLayout():
     def __init__(self):
         self.name = DEF_LAYOUT_NAME
         self.font = DEF_FONT
-        self.font_color = DEF_FONT_COLOR
         self.background_color = DEF_BACKGROUND_COLOR
         self.margin = DEF_MARGIN
         self.key_width = DEF_KEY_WIDTH
@@ -78,7 +77,7 @@ class StenoLayout():
 
         self.name = data['name'] if 'name' in data else DEF_LAYOUT_NAME
         self.font = data['font'] if 'font' in data else DEF_FONT
-        self.font_color = data['font_color'] if 'font_color' in data else DEF_FONT_COLOR
+        font_color = data['font_color'] if 'font_color' in data else DEF_FONT_COLOR
         self.background_color = data['background_color'] if 'background_color' in data else DEF_BACKGROUND_COLOR
         self.margin = data['margin'] if 'margin' in data else DEF_MARGIN
         self.key_width = data['key_width'] if 'key_width' in data else DEF_KEY_WIDTH
@@ -97,5 +96,6 @@ class StenoLayout():
                 key['is_round_top'] if 'is_round_top' in key else False,
                 key['is_round_bottom'] if 'is_round_bottom' in key else False,
                 key['color'] if 'color' in key else DEF_KEY_COLOR,
-                key['color_pressed'] if 'color_pressed' in key else DEF_KEY_COLOR_PRESSED
+                key['color_pressed'] if 'color_pressed' in key else DEF_KEY_COLOR_PRESSED,
+                key['font_color'] if 'font_color' in key else font_color
             ))

--- a/layout_display/steno_layout.py
+++ b/layout_display/steno_layout.py
@@ -16,6 +16,7 @@ class StenoLayout():
     ''' Represents the structure of a stenography layout '''
 
     name: str = 'Default Layout Name'
+    font: str = ''
     margin: float = 5.0
     key_width: int = 30
     key_height: int = 35
@@ -60,6 +61,8 @@ class StenoLayout():
 
         if 'name' in data:
             self.name = data['name']
+        if 'font' in data:
+            self.font = data['font']
         if 'margin' in data:
             self.margin = data['margin']
         if 'key_width' in data:

--- a/layout_display/steno_layout.py
+++ b/layout_display/steno_layout.py
@@ -5,6 +5,22 @@ from typing import List
 from PyQt5 import QtCore
 
 
+DEF_LAYOUT_NAME = 'Default Layout Name'
+DEF_FONT = ''
+DEF_FONT_COLOR = '#000000'
+DEF_BACKGROUND_COLOR = '#FFFFFF'
+DEF_MARGIN = 5.0
+DEF_KEY_WIDTH = 30
+DEF_KEY_HEIGHT = 35
+
+DEF_KEY_LABEL = ''
+DEF_KEY_WIDTH_UNIT = 1.0
+DEF_KEY_HEIGHT_UNIT = 1.0
+DEF_KEY_POS_X = 0.0
+DEF_KEY_POS_Y = 0.0
+DEF_KEY_COLOR = ''
+DEF_KEY_COLOR_PRESSED = '#000000'
+
 StenoKey = namedtuple('StenoKey',
                       'name label ' +
                       'position_x position_y ' +
@@ -15,15 +31,16 @@ StenoKey = namedtuple('StenoKey',
 class StenoLayout():
     ''' Represents the structure of a stenography layout '''
 
-    name: str = 'Default Layout Name'
-    font: str = ''
-    margin: float = 5.0
-    key_width: int = 30
-    key_height: int = 35
-    keys: List[StenoKey] = []
-
     def __init__(self):
-        pass
+        self.name = DEF_LAYOUT_NAME
+        self.font = DEF_FONT
+        self.font_color = DEF_FONT_COLOR
+        self.background_color = DEF_BACKGROUND_COLOR
+        self.margin = DEF_MARGIN
+        self.key_width = DEF_KEY_WIDTH
+        self.key_height = DEF_KEY_HEIGHT
+
+        self.keys: List[StenoKey] = []
 
     def load_from_file(self, file_path: str):
         ''' Populates layout information from the provided file path '''
@@ -59,28 +76,26 @@ class StenoLayout():
     def load_from_json(self, data: dict):
         ''' Populates layout information from the provided JSON data '''
 
-        if 'name' in data:
-            self.name = data['name']
-        if 'font' in data:
-            self.font = data['font']
-        if 'margin' in data:
-            self.margin = data['margin']
-        if 'key_width' in data:
-            self.key_width = data['key_width']
-        if 'key_height' in data:
-            self.key_height = data['key_height']
+        self.name = data['name'] if 'name' in data else DEF_LAYOUT_NAME
+        self.font = data['font'] if 'font' in data else DEF_FONT
+        self.font_color = data['font_color'] if 'font_color' in data else DEF_FONT_COLOR
+        self.background_color = data['background_color'] if 'background_color' in data else DEF_BACKGROUND_COLOR
+        self.margin = data['margin'] if 'margin' in data else DEF_MARGIN
+        self.key_width = data['key_width'] if 'key_width' in data else DEF_KEY_WIDTH
+        self.key_height = data['key_height'] if 'key_height' in data else DEF_KEY_HEIGHT
 
         self.keys = []
         for key in data['keys']:
             self.keys.append(StenoKey(
+                # Make sure that name always exists; we'll default to unique
                 key['name'] if 'name' in key else str(len(self.keys)),
-                key['label'] if 'label' in key else '',
-                key['position_x'] if 'position_x' in key else 0.0,
-                key['position_y'] if 'position_y' in key else 0.0,
-                key['width'] if 'width' in key else 1.0,
-                key['height'] if 'height' in key else 1.0,
+                key['label'] if 'label' in key else DEF_KEY_LABEL,
+                key['position_x'] if 'position_x' in key else DEF_KEY_POS_X,
+                key['position_y'] if 'position_y' in key else DEF_KEY_POS_Y,
+                key['width'] if 'width' in key else DEF_KEY_WIDTH_UNIT,
+                key['height'] if 'height' in key else DEF_KEY_HEIGHT_UNIT,
                 key['is_round_top'] if 'is_round_top' in key else False,
                 key['is_round_bottom'] if 'is_round_bottom' in key else False,
-                key['color'] if 'color' in key else '',
-                key['color_pressed'] if 'color_pressed' in key else '#000000'
+                key['color'] if 'color' in key else DEF_KEY_COLOR,
+                key['color_pressed'] if 'color_pressed' in key else DEF_KEY_COLOR_PRESSED
             ))

--- a/layout_display/steno_layout.py
+++ b/layout_display/steno_layout.py
@@ -76,33 +76,33 @@ class StenoLayout():
         except (jsonschema.ValidationError, jsonschema.SchemaError) as error:
             return False
 
-        self.name = data['name'] if 'name' in data else DEF_LAYOUT_NAME
-        self.margin = data['margin'] if 'margin' in data else DEF_MARGIN
-        self.key_width = data['key_width'] if 'key_width' in data else DEF_KEY_WIDTH
-        self.key_height = data['key_height'] if 'key_height' in data else DEF_KEY_HEIGHT
-        self.font = data['font'] if 'font' in data else DEF_FONT
-        font_color = data['font_color'] if 'font_color' in data else DEF_FONT_COLOR
-        self.background_color = data['background_color'] if 'background_color' in data else DEF_BACKGROUND_COLOR
-        key_stroke_color = data['key_stroke_color'] if 'key_stroke_color' in data else DEF_STROKE_COLOR
-        key_color = data['key_color'] if 'key_color' in data else DEF_KEY_COLOR
-        key_color_pressed = data['key_color'] if 'key_color' in data else DEF_KEY_COLOR_PRESSED
+        self.name = data.get('name', DEF_LAYOUT_NAME)
+        self.margin = data.get('margin', DEF_MARGIN)
+        self.key_width = data.get('key_width', DEF_KEY_WIDTH)
+        self.key_height = data.get('key_height', DEF_KEY_HEIGHT)
+        self.font = data.get('font', DEF_FONT)
+        font_color = data.get('font_color', DEF_FONT_COLOR)
+        self.background_color = data.get('background_color', DEF_BACKGROUND_COLOR)
+        key_stroke_color = data.get('key_stroke_color', DEF_STROKE_COLOR)
+        key_color = data.get('key_color', DEF_KEY_COLOR)
+        key_color_pressed = data.get('key_color', DEF_KEY_COLOR_PRESSED)
 
         self.keys = []
         for key in data['keys']:
             self.keys.append(StenoKey(
                 # Make sure that name always exists; we'll default to unique
-                key['name'] if 'name' in key else str(len(self.keys)),
-                key['label'] if 'label' in key else DEF_KEY_LABEL,
-                key['x'] if 'x' in key else DEF_KEY_POS_X,
-                key['y'] if 'y' in key else DEF_KEY_POS_Y,
-                key['width'] if 'width' in key else DEF_KEY_WIDTH_UNIT,
-                key['height'] if 'height' in key else DEF_KEY_HEIGHT_UNIT,
-                key['is_round_top'] if 'is_round_top' in key else False,
-                key['is_round_bottom'] if 'is_round_bottom' in key else False,
-                key['font_color'] if 'font_color' in key else font_color,
-                key['stroke_color'] if 'stroke_color' in key else key_stroke_color,
-                key['color'] if 'color' in key else key_color,
-                key['color_pressed'] if 'color_pressed' in key else key_color_pressed
+                key.get('name', str(len(self.keys))),
+                key.get('label', DEF_KEY_LABEL),
+                key.get('x', DEF_KEY_POS_X),
+                key.get('y', DEF_KEY_POS_Y),
+                key.get('width', DEF_KEY_WIDTH_UNIT),
+                key.get('height', DEF_KEY_HEIGHT_UNIT),
+                key.get('is_round_top', False),
+                key.get('is_round_bottom', False),
+                key.get('font_color', font_color),
+                key.get('stroke_color', key_stroke_color),
+                key.get('color', key_color),
+                key.get('color_pressed', key_color_pressed)
             ))
 
         return True

--- a/layout_display/steno_layout.py
+++ b/layout_display/steno_layout.py
@@ -9,6 +9,7 @@ import jsonschema
 DEF_LAYOUT_NAME = 'Default Layout Name'
 DEF_FONT = ''
 DEF_FONT_COLOR = '#000000'
+DEF_STROKE_COLOR = '#000000'
 DEF_BACKGROUND_COLOR = '#FFFFFF'
 DEF_MARGIN = 5.0
 DEF_KEY_WIDTH = 30.0
@@ -27,7 +28,7 @@ StenoKey = namedtuple('StenoKey',
                       'position_x position_y ' +
                       'width height ' +
                       'is_round_top is_round_bottom ' +
-                      'color color_pressed font_color')
+                      'color color_pressed font_color stroke_color')
 
 class StenoLayout():
     ''' Represents the structure of a stenography layout '''
@@ -78,6 +79,7 @@ class StenoLayout():
         self.name = data['name'] if 'name' in data else DEF_LAYOUT_NAME
         self.font = data['font'] if 'font' in data else DEF_FONT
         font_color = data['font_color'] if 'font_color' in data else DEF_FONT_COLOR
+        stroke_color = data['stroke_color'] if 'stroke_color' in data else DEF_STROKE_COLOR
         self.background_color = data['background_color'] if 'background_color' in data else DEF_BACKGROUND_COLOR
         self.margin = data['margin'] if 'margin' in data else DEF_MARGIN
         self.key_width = data['key_width'] if 'key_width' in data else DEF_KEY_WIDTH
@@ -97,7 +99,8 @@ class StenoLayout():
                 key['is_round_bottom'] if 'is_round_bottom' in key else False,
                 key['color'] if 'color' in key else DEF_KEY_COLOR,
                 key['color_pressed'] if 'color_pressed' in key else DEF_KEY_COLOR_PRESSED,
-                key['font_color'] if 'font_color' in key else font_color
+                key['font_color'] if 'font_color' in key else font_color,
+                key['stroke_color'] if 'stroke_color' in key else stroke_color
             ))
 
         return True

--- a/layout_display/steno_layout.py
+++ b/layout_display/steno_layout.py
@@ -16,7 +16,7 @@ class StenoLayout():
     ''' Represents the structure of a stenography layout '''
 
     name: str = 'Default Layout Name'
-    padding: float = 4.0
+    margin: float = 5.0
     key_width: int = 30
     key_height: int = 35
     keys: List[StenoKey] = []
@@ -60,8 +60,8 @@ class StenoLayout():
 
         if 'name' in data:
             self.name = data['name']
-        if 'padding' in data:
-            self.padding = data['padding']
+        if 'margin' in data:
+            self.margin = data['margin']
         if 'key_width' in data:
             self.key_width = data['key_width']
         if 'key_height' in data:
@@ -85,9 +85,9 @@ class StenoLayout():
     def get_width(self) -> int:
         ''' Calculates the width the layout requires '''
 
-        return max(self.padding + key.position_x + key.width * self.key_width for key in self.keys)
+        return max(self.margin + key.position_x + key.width * self.key_width for key in self.keys)
 
     def get_height(self) -> int:
         ''' Calculates the height the layout requires '''
 
-        return max(self.padding + key.position_y + key.height * self.key_height for key in self.keys)
+        return max(self.margin + key.position_y + key.height * self.key_height for key in self.keys)

--- a/layout_display/steno_layout.py
+++ b/layout_display/steno_layout.py
@@ -1,0 +1,93 @@
+from collections import namedtuple
+import json
+from typing import List
+
+from PyQt5 import QtCore
+
+
+StenoKey = namedtuple('StenoKey',
+                      'name label ' +
+                      'position_x position_y ' +
+                      'width height ' +
+                      'is_round_top is_round_bottom ' +
+                      'color color_pressed')
+
+class StenoLayout():
+    ''' Represents the structure of a stenography layout '''
+
+    name: str = 'Default Layout Name'
+    padding: float = 4.0
+    key_width: int = 30
+    key_height: int = 35
+    keys: List[StenoKey] = []
+
+    def __init__(self):
+        pass
+
+    def load_from_file(self, file_path: str):
+        ''' Populates layout information from the provided file path '''
+
+        try:
+            with open(file_path, encoding='utf-8') as file:
+                data = json.load(file)
+
+            self.load_from_json(data)
+        except:
+            pass
+
+    def load_from_resource(self, resource_path: str):
+        ''' Populates layout information from the provided Qt resource path '''
+
+        try:
+            file = QtCore.QFile(resource_path)
+
+            if file.open(QtCore.QIODevice.ReadOnly | QtCore.QFile.Text):
+                text_stream = QtCore.QTextStream(file)
+                text_stream.setCodec('utf-8')
+                text_stream.setAutoDetectUnicode(True)
+
+                file_text = text_stream.readAll()
+                file.close()
+
+            data = json.loads(str(file_text))
+
+            self.load_from_json(data)
+        except:
+            pass
+
+    def load_from_json(self, data):
+        ''' Populates layout information from the provided JSON data '''
+
+        if 'name' in data:
+            self.name = data['name']
+        if 'padding' in data:
+            self.padding = data['padding']
+        if 'key_width' in data:
+            self.key_width = data['key_width']
+        if 'key_height' in data:
+            self.key_height = data['key_height']
+
+        self.keys = []
+        for key in data['keys']:
+            self.keys.append(StenoKey(
+                key['name'] if 'name' in key else str(len(self.keys)),
+                key['label'] if 'label' in key else '',
+                key['position_x'] if 'position_x' in key else 0.0,
+                key['position_y'] if 'position_y' in key else 0.0,
+                key['width'] if 'width' in key else 1.0,
+                key['height'] if 'height' in key else 1.0,
+                key['is_round_top'] if 'is_round_top' in key else False,
+                key['is_round_bottom'] if 'is_round_bottom' in key else False,
+                key['color'] if 'color' in key else '',
+                key['color_pressed'] if 'color_pressed' in key else '#000000'
+            ))
+
+    def get_width(self) -> int:
+        ''' Calculates the width the layout requires '''
+
+        return max(self.padding + key.position_x + key.width * self.key_width for key in self.keys)
+
+    def get_height(self) -> int:
+        ''' Calculates the height the layout requires '''
+
+        return max(self.padding + key.position_y + key.height * self.key_height for key in self.keys)

--- a/layout_display/steno_layout.py
+++ b/layout_display/steno_layout.py
@@ -55,7 +55,7 @@ class StenoLayout():
         except:
             pass
 
-    def load_from_json(self, data):
+    def load_from_json(self, data: dict):
         ''' Populates layout information from the provided JSON data '''
 
         if 'name' in data:
@@ -81,13 +81,3 @@ class StenoLayout():
                 key['color'] if 'color' in key else '',
                 key['color_pressed'] if 'color_pressed' in key else '#000000'
             ))
-
-    def get_width(self) -> int:
-        ''' Calculates the width the layout requires '''
-
-        return max(self.margin + key.position_x + key.width * self.key_width for key in self.keys)
-
-    def get_height(self) -> int:
-        ''' Calculates the height the layout requires '''
-
-        return max(self.margin + key.position_y + key.height * self.key_height for key in self.keys)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = plover_layout_display
 version = 0.0.2
-description = Display last chord hit in Plover
+description = Display the last stroke in Plover
 long_description = file: README.rst
 author = Ted Morin
 author_email = morinted@gmail.com
@@ -22,6 +22,7 @@ keywords = plover plover_plugin
 zip_safe = True
 install_requires =
 	plover>=4.0.0.dev2
+	jsonschema
 packages =
 	layout_display
 


### PR DESCRIPTION
I've been sitting on this for a little while so I figured I should just make a pull request and see what you think about the changes.

I added the ability to load JSON files to change how the layout is displayed. This includes the requested options for labeling, colors (font, stroke, key, pressed key, background), and support for custom theories by the nature of you arbitrarily being able to assign system keys for each key (fixes #2). It also involved a lot of code changes to shift from just using a painter to a graphics scene / view in a vertical layout.

The README file may need some updates. The screenshots were just quick examples I threw up there and I'm not sure the best way to link to the JSON schema file for people to reference when creating custom layouts (right now, it's perma-linked to an old version even.). I'm also not sure on what the best way people can share some good pre-made layouts (maybe a wiki page?).

Some things that I didn't finish:
- More efficient scene updating. It'd be nice to construct a scene on layout load and then only update the colors of keys as they are pressed to be a bit more efficient.
- Arbitrary label placement. Currently if labels are specified they are centered on the key they are set for. In cases like Michela it could be useful for the labels to be specified at an offset to some capacity.
- Potentially some sort of warning message when an invalid layout file is loaded rather than reverting back to the default.