### PR TITLE
fix setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+	"plover[gui_qt]>=4.0.0.dev10",
+	"setuptools>=38.2.4",
+	"wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,15 @@
 
 from setuptools import setup
 
-from plover_build_utils.setup import BuildPy, BuildUi
+from plover_build_utils.setup import BuildPy, BuildUi, Develop
 
 BuildPy.build_dependencies.append('build_ui')
 BuildUi.hooks = ['plover_build_utils.pyqt:fix_icons']
+Develop.build_dependencies.append('build_py')
 cmdclass = {
     'build_py': BuildPy,
     'build_ui': BuildUi,
+    'develop': Develop,
 }
 
 setup(cmdclass=cmdclass)

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python3
 
-__requires__ = '''
-plover>=4.0.0.dev2
-setuptools>=30.3.0
-'''
-
 from setuptools import setup
 
 from plover_build_utils.setup import BuildPy, BuildUi


### PR DESCRIPTION
* fix build requirements: add `pyproject.toml`, and ensure PyQt5 is available (by depending on `plover[gui_qt]`)
* fix editable installation: ensure the `develop` command generate the UI files